### PR TITLE
Use stable, not broken, version of keystone

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/JedWatson/keystone-demo.git"
   },
   "dependencies": {
-    "keystone": "https://github.com/keystonejs/keystone.git",
+    "keystone": "^0.3.15",
     "async": "^1.5.0",
     "lodash": "^3.10.1",
     "csv": "^0.4.6",


### PR DESCRIPTION
At the moment, running `npm install` on keystone-demo results in a broken setup (500 when attempting to create new blog/gallery/etc). 

Keystone repo README states that "Work on this has now been merged into our master branch, which is currently not stable (but which we encourage you to try out and give us feedback on!). Stable 0.3.x releases will continue to be published from the 0.3.x branch."

This PR locks the version of keystone.js to the latest stable version, 0.3.15. 

Locking the version allows keystone-demo to work but unfortunately the keystone.js version will have to be updated at some point in the future.
