### PR TITLE
Adding Nitrous.io QuickStart For Easy Development Or Demonstration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ We reccommend you use our new [Yeoman Generator](https://github.com/JedWatson/ge
 
 If you do want to use this as a starting point however, you are welcome, follow the instructions below to begin.
 
+# Nitrous QuickStart
+
+You can quickly create a free development environment to get started using this
+demo in the cloud on [Nitrous](https://www.nitrous.io/):
+
+<a href="https://www.nitrous.io/quickstart?repo=https://github.com/tmvanetten/keystone-demo">
+  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous QuickStart" width=142 height=34>
+</a>
+
+# Manual Install
+
 *Note: We're implementing a new theme for the demo site; to use the (old) basic bootstrap theme, check out the `bootstrap-simple` branch*
 
     git clone https://github.com/JedWatson/keystone-demo.git

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -23,7 +23,5 @@ sudo apt-get install -y mongodb-org
 
 # Remember Nitrous automatically cloned the repo into ~/code/{$GIT_REPO_NAME} so at this point all we need to do is cd into our
 #+ project, install our node dependencies, and we are ready to laucnch the demo app.
-echo "installing node modules...."
+echo "installing node modules and opening the Nitrous.io IDE...."
 cd ~/code/keystone-demo && npm install --no-progress
-echo "node modules installed"
-echo "launching the Keystone-Demo App in the Nitrous IDE..."

--- a/nitrous-post-create.sh
+++ b/nitrous-post-create.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# KeystoneJS Demo App - Nitrous QuiskStart post create script by @tmvanetten
+
+#KeystoneJS Demo App is used IAW https://github.com/keystonejs/keystone-demo#license
+#+ and with thanks to https://github.com/JedWatson and all contributors.
+
+#  Note:
+#  -------
+#  This script uses Nitrous.io QuickStart to spin up an Ubuntu instance with Node and Mongo.  It will pull the
+#+ Keystone-Demo repo, install the node dependencies, configure port 3000 to open/public, and launch the Nitrous.io IDE.
+#  You can customize the demo app by editing the name and brand in keystone.js and modify the rest
+#+ to fit your project needs.
+# When your ready to check out the demo app type node keystone in the terminal and then click preview on 3000 in the Nitrous.io IDE.
+
+# Based on the repo url included in our QuickStart button, Nitrous will automatically clone the repo for us and place it
+#+ into ~/code/{$GIT_REPO_NAME} .
+
+# let's get mongo ready locally for our keystone.js demo app
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
+echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
+sudo apt-get update
+sudo apt-get install -y mongodb-org
+
+# Remember Nitrous automatically cloned the repo into ~/code/{$GIT_REPO_NAME} so at this point all we need to do is cd into our
+#+ project, install our node dependencies, and we are ready to laucnch the demo app.
+echo "installing node modules...."
+cd ~/code/keystone-demo && npm install --no-progress
+echo "node modules installed"
+echo "launching the Keystone-Demo App in the Nitrous IDE..."

--- a/nitrous.json
+++ b/nitrous.json
@@ -1,0 +1,7 @@
+{
+  "template": "nodejs",
+  "ports": [3000],
+  "name": "Keystone Demo",
+  "logo": "http://keystonejs.com/images/logo.svg",
+  "description": "Keystone-Demo App Nitrous.io QuickStart"
+}


### PR DESCRIPTION
@JedWatson  I propose adding a Nitrous.io QuickStart button as an option for "quick and easy" development and playing around with the keystone-demo app.

The QuickStart button via the nitrous.json and nitrous-post-create.sh spins up a nitrous.io node container, installs mongo, updates local packages, opens port 3000, installs node dependencies (takes a few minutes), and launches the nitrous.io ide.  

Once the ide opens users can cd ~/code/keystone-demo && node keystone and then click on the Preview > 3000 link in the menubar to have their own keystone-demo app dev environment running.

Nitrous.io does require users to have an account but they do offer a free tier.