### PR TITLE
Run the theme middleware on 404.

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -17,6 +17,7 @@ keystone.pre('render', middleware.theme);
 keystone.pre('render', middleware.flashMessages);
 
 keystone.set('404', function (req, res, next) {
+    middleware.theme(req, res, next);
 	res.status(404).render('errors/404');
 });
 


### PR DESCRIPTION
Fixes #27.

The middleware isn't running automatically here. I'm not entirely sure why, given we're setting `keystone.pre('render', middleware.theme);`, but I guess doing `res.status(404).render('errors/404');` doesn't trigger this for some reason.

@JedWatson Could this be an indicator of a larger problem, or is it just a quirk of how the theme middleware is setup? (Note the `flashMessages` middleware isn't running either).