### PR TITLE
Update README.md: removed Nitrous section

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@ We reccommend you use our new [Yeoman Generator](https://github.com/JedWatson/ge
 
 If you do want to use this as a starting point however, you are welcome, follow the instructions below to begin.
 
-# Nitrous QuickStart
-
-You can quickly create a free development environment to get started using this
-demo in the cloud on [Nitrous](https://www.nitrous.io/):
-
-<a href="https://www.nitrous.io/quickstart?repo=https://github.com/tmvanetten/keystone-demo">
-  <img src="https://nitrous-image-icons.s3.amazonaws.com/quickstart.png" alt="Nitrous QuickStart" width=142 height=34>
-</a>
-
 # Manual Install
 
 *Note: We're implementing a new theme for the demo site; to use the (old) basic bootstrap theme, check out the `bootstrap-simple` branch*


### PR DESCRIPTION
See #78 
https://techcrunch.com/2016/10/31/cloud-development-platform-nitrous-io-shuts-down/